### PR TITLE
Add random dungeon generator to API and home page

### DIFF
--- a/dungen/dungen-lib-test/TerrainGen/TestTerrainGenAlgorithms.cs
+++ b/dungen/dungen-lib-test/TerrainGen/TestTerrainGenAlgorithms.cs
@@ -12,6 +12,7 @@ using DunGen.Algorithm;
 using DunGen.Plugins;
 using DunGen.Generator;
 using DunGen.Tiles;
+using System.Linq;
 
 namespace DunGen.Lib.Test
 {
@@ -90,6 +91,42 @@ namespace DunGen.Lib.Test
           continue;
         }
       }
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(System.NotImplementedException))]
+    public void RunWithoutMask()
+    {
+      Random r = new Random();
+
+      var allAlgs = AlgorithmPluginEnumerator.GetAllLoadedAlgorithms();
+      foreach (var algProto in allAlgs)
+      {
+        var runs = new List<AlgorithmRun>
+        {
+          new AlgorithmRun()
+          {
+            Alg = algProto.Clone() as IAlgorithm,
+            Context = new AlgorithmContextBase()
+            {
+              R = new AlgorithmRandom(r.Next())
+            }
+          }
+        };
+
+        var generator = new DungeonGenerator();
+        generator.Options = new DungeonGenerator.DungeonGeneratorOptions()
+        {
+          DoReset = true,
+          EgressConnections = null,
+          Width = 25,
+          Height = 25,
+          AlgRuns = runs
+        };
+
+        var dungeon = generator.Generate();
+      }
+
     }
 
     // TODO use answer at this link to devise a reflective way to create individual tests for each algorithm in a huge dungeon

--- a/dungen/dungen-site/ClientApp/src/app/app.module.ts
+++ b/dungen/dungen-site/ClientApp/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { NavMenuComponent } from './nav-menu/nav-menu.component';
 import { HomeComponent } from './home/home.component';
 import { CounterComponent } from './counter/counter.component';
 import { FetchDataComponent } from './fetch-data/fetch-data.component';
+import { RandomDungeonComponent } from './random-dungeon/random-dungeon.component';
 
 @NgModule({
   declarations: [
@@ -16,7 +17,8 @@ import { FetchDataComponent } from './fetch-data/fetch-data.component';
     NavMenuComponent,
     HomeComponent,
     CounterComponent,
-    FetchDataComponent
+    FetchDataComponent,
+    RandomDungeonComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),

--- a/dungen/dungen-site/ClientApp/src/app/home/home.component.html
+++ b/dungen/dungen-site/ClientApp/src/app/home/home.component.html
@@ -11,3 +11,5 @@
 <h2>Upcoming</h2>
 <p>Once developed, this website will expose an interface for ✨customizing algorithms, ✨painting a dungeon layout (think "I want a maze here and a cave there," not individual tiles in your grid), and ✨editing dungeons at any stage of generation.</p>
 <p><em>But right now, it's just this page</em> 😭😭😭</p>
+<h2>Sample</h2>
+<app-random-dungeon></app-random-dungeon>

--- a/dungen/dungen-site/ClientApp/src/app/home/home.component.ts
+++ b/dungen/dungen-site/ClientApp/src/app/home/home.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
 })
 export class HomeComponent {
+
+  constructor(http: HttpClient, @Inject('BASE_URL') baseUrl: string) {
+  }
 }

--- a/dungen/dungen-site/ClientApp/src/app/random-dungeon/random-dungeon.component.html
+++ b/dungen/dungen-site/ClientApp/src/app/random-dungeon/random-dungeon.component.html
@@ -1,0 +1,6 @@
+<div>
+  <input type="button" value="Get {{clickedEver ? 'Another' : 'A'}} Dungeon" (click)="getNewDungeon()" /> <br />
+  <p *ngIf="clickedEver && !randomDungeonBase64"><em>Loading...</em></p>
+  <img *ngIf="randomDungeonBase64" [src]='this.randomDungeonBase64' alt="A randomly-generated dungeon!" /> <br />
+  <small><em>This is still a work in progress, so some algorithms won't show much. Keep clicking until you find an interesting one!</em></small>
+</div>

--- a/dungen/dungen-site/ClientApp/src/app/random-dungeon/random-dungeon.component.ts
+++ b/dungen/dungen-site/ClientApp/src/app/random-dungeon/random-dungeon.component.ts
@@ -1,0 +1,45 @@
+import { Component, Inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-random-dungeon',
+  templateUrl: './random-dungeon.component.html',
+})
+export class RandomDungeonComponent {
+  private http: HttpClient;
+  public randomDungeonBase64: string;
+  public randId: number;
+  public clickedEver: boolean = false;
+
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  getNewDungeon() {
+    this.clickedEver = true;
+    this.randId = Math.floor(Math.random() * 99998) + 1;
+    var randoDungeonUrl = 'api/randomdungeon/' + this.randId;
+    console.log("Nabbing " + randoDungeonUrl);
+    this.http.get(randoDungeonUrl, { responseType: 'blob' })
+      .subscribe(result => this.updateDungeon(result),
+        error => console.log("Un-implemented algorithm was randomly selected, or something else went wrong."));
+  }
+
+  updateDungeon(newImage: Blob) {
+    var reader = new FileReader();
+    reader.readAsDataURL(newImage);
+    reader.onload = (function (component, reader) {
+      return function (e) {
+        var binaryData = reader.result;
+        if (typeof binaryData === 'string') {
+          component.randomDungeonBase64 = binaryData;
+          console.log("Processed base64: " + binaryData);
+        }
+      };
+    })(this, reader);
+  }
+
+  assignBase64(fr: FileReader) {
+
+  }
+}

--- a/dungen/dungen-site/Controllers/WeatherForecastController.cs
+++ b/dungen/dungen-site/Controllers/WeatherForecastController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
-namespace dungen_site.Controllers
+namespace DunGen.Site.Controllers
 {
     [ApiController]
     [Route("[controller]")]

--- a/dungen/dungen-site/Pages/Error.cshtml.cs
+++ b/dungen/dungen-site/Pages/Error.cshtml.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
-namespace dungen_site.Pages
+namespace DunGen.Site.Pages
 {
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel

--- a/dungen/dungen-site/Pages/_ViewImports.cshtml
+++ b/dungen/dungen-site/Pages/_ViewImports.cshtml
@@ -1,3 +1,3 @@
-@using dungen_site
-@namespace dungen_site.Pages
+@using DunGen.Site
+@namespace DunGen.Site.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/dungen/dungen-site/Program.cs
+++ b/dungen/dungen-site/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace dungen_site
+namespace DunGen.Site
 {
     public class Program
     {
@@ -22,7 +22,8 @@ namespace dungen_site
                 {
                   var port = Environment.GetEnvironmentVariable("PORT");
                   webBuilder.UseStartup<Startup>()
-                            .UseUrls("http://*:" + port);
+                            .UseUrls("http://*:" + port)
+                            .CaptureStartupErrors(true);
                 });
     }
 }

--- a/dungen/dungen-site/Startup.cs
+++ b/dungen/dungen-site/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace dungen_site
+namespace DunGen.Site
 {
     public class Startup
     {

--- a/dungen/dungen-site/WeatherForecast.cs
+++ b/dungen/dungen-site/WeatherForecast.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace dungen_site
+namespace DunGen.Site
 {
     public class WeatherForecast
     {

--- a/dungen/dungen-site/dungen-site.csproj
+++ b/dungen/dungen-site/dungen-site.csproj
@@ -10,7 +10,7 @@
 
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
-    <RootNamespace>dungen_site</RootNamespace>
+    <RootNamespace>DunGen.Site</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +23,10 @@
     <Content Remove="$(SpaRoot)**" />
     <None Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dungen-lib\dungen-lib.csproj" />
   </ItemGroup>
 
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">


### PR DESCRIPTION
## Overview
Part of #34. But it is not done.

This PR merges changes to `dungen-site` to embed into the home page a randomly generated dungeon map. It would be good to limit this random generator to a curated palette of custom algorithms, so each dungeon is a bit more "showy." However, this serves to at least create the web visualization, so we can futz with quality later on.

The next part of #34 will be to create a dedicated page that does the same thing, but tells you what algorithm was run, how long it took, and lets you download the `.dgd` file.

## Proposed Changes
* Adds a new Angular component: `random-dungeon`, and embeds it into home component.

## Considerations & Notes
* It was a learning experience to get the base64 embedded into the page without saving it to the server (Heroku) filesystem. Boy howdy I am not a seasoned Angular dev :)

## Commit Summary
* Adds new ASP.NET controller and exposes API for getting rando dungeons
* Adds new component: random-dungeon
* Also fixes assembly namespacing for dungen-site project