### PR TITLE
Correct math in LinearRecursiveDivision algorithm

### DIFF
--- a/dungen/dungen-lib/TerrainGen/LinearRecursiveDivision.cs
+++ b/dungen/dungen-lib/TerrainGen/LinearRecursiveDivision.cs
@@ -177,8 +177,8 @@ namespace DunGen.TerrainGen
         // Origin of new wall - TODO is there more efficient math for this?
         int wx_offset_base = (int)((1.0 - Variability) / 2.0 * currentRegion.Width);
         int wy_offset_base = (int)((1.0 - Variability) / 2.0 * currentRegion.Height);
-        int wx_offset_rand = ((int)Math.Ceiling(Variability * r.NextDouble() * currentRegion.Width)) - 1;
-        int wy_offset_rand = ((int)Math.Ceiling(Variability * r.NextDouble() * currentRegion.Height)) - 1;
+        int wx_offset_rand = ((int)Math.Floor(Variability * r.NextDouble() * (currentRegion.Width - 1)));
+        int wy_offset_rand = ((int)Math.Floor(Variability * r.NextDouble() * (currentRegion.Height - 1)));
         int wx_offset = wx_offset_base + wx_offset_rand;
         int wy_offset = wy_offset_base + wy_offset_rand;
         int wx = currentRegion.X + (doHoriz ? 0 : wx_offset);

--- a/dungen/dungen-site/Controllers/RandomDungeonController.cs
+++ b/dungen/dungen-site/Controllers/RandomDungeonController.cs
@@ -53,6 +53,12 @@ namespace DunGen.Site.Controllers
         RoomSize = 16,
         RoomSizeVariability = 30
       },
+      new LinearRecursiveDivision()
+      {
+        RoomSize = 10,
+        RoomSizeVariability = 10,
+        Variability = 0.4
+      },
       new RecursiveBacktracker()
       {
         WallStrategy = TerrainGenAlgorithmBase.WallFormation.Tiles


### PR DESCRIPTION
## Overview
Fixes #40.

This PR merges changes to `dungen` to correct the issue, `dungen-cli` to add new flags to the `generator go` predicate to enable debugging, and `dungen-site` to add another instance of `LinearRecursiveDivision` to the site's palette.

The re was a math error causing total closures, as the south or eastmost tiles could be selected for being filled in, and the algorithm fills walls by walling up south and east borders.